### PR TITLE
PHPUnit^9へ更新・キャッシュ・ファクトリー・祝日ロジックの不具合を修正 (v6系)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,8 @@ grind/*
 composer.lock
 
 .php_cs.cache
+
+.phpunit.result.cache
+.php-cs-fixer.cache
+.phpunit.cache/
+

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 日本の祝日、暦など日本での日付処理(Date processing including Japanese holiday processing)
 =========================================
-[![CircleCI](https://circleci.com/gh/suzunone/JapaneseDate.svg?style=svg)](https://circleci.com/gh/suzunone/JapaneseDate)
-
-
 Introduction
 -----------------------------------------
 

--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
     "symfony/polyfill-ctype": "^1.20"
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.4.4",
-    "mockery/mockery": "^1.2.0",
-    "fzaninotto/faker": "^v1.7.1"
+    "phpunit/phpunit": "^9.0",
+    "mockery/mockery": "*",
+    "fzaninotto/faker": "*"
   },
   "autoload": {
     "psr-4": {

--- a/src/Components/Cache.php
+++ b/src/Components/Cache.php
@@ -64,6 +64,10 @@ class Cache extends CacheMode
      */
     public static function forever(string $cache_name, Closure $function)
     {
+        if (static::$mode === static::MODE_NONE) {
+            return $function();
+        }
+
         $cache = &static::$cache;
 
         if (isset($cache[$cache_name])) {

--- a/src/Components/JapaneseDate.php
+++ b/src/Components/JapaneseDate.php
@@ -217,7 +217,7 @@ class JapaneseDate
         $res = [];
         $res[1] = DateTime::NEW_YEAR_S_DAY;
         // 振替休日確認
-        if ($this->getWeekday(mktime(0, 0, 0, 1, 1, $year), $timezone) === DateTime::SUNDAY) {
+        if ($year >= 1974 && $this->getWeekday(mktime(0, 0, 0, 1, 1, $year), $timezone) === DateTime::SUNDAY) {
             $res[2] = DateTime::COMPENSATING_HOLIDAY;
         }
         if ($year >= 2000) {
@@ -227,7 +227,7 @@ class JapaneseDate
         } else {
             $res[15] = DateTime::COMING_OF_AGE_DAY;
             // 振替休日確認
-            if ($this->getWeekday(mktime(0, 0, 0, 1, 15, $year), $timezone) === DateTime::SUNDAY) {
+            if ($year >= 1974 && $this->getWeekday(mktime(0, 0, 0, 1, 15, $year), $timezone) === DateTime::SUNDAY) {
                 $res[16] = DateTime::COMPENSATING_HOLIDAY;
             }
         }
@@ -311,11 +311,12 @@ class JapaneseDate
         }
 
         $res = [];
-        $res[11] = DateTime::NATIONAL_FOUNDATION_DAY;
-
-        // 振替休日確認
-        if ($this->getWeekday(mktime(0, 0, 0, 2, 11, $year), $timezone) === DateTime::SUNDAY) {
-            $res[12] = DateTime::COMPENSATING_HOLIDAY;
+        if ($year >= 1967) {
+            $res[11] = DateTime::NATIONAL_FOUNDATION_DAY;
+            // 振替休日確認
+            if ($year >= 1974 && $this->getWeekday(mktime(0, 0, 0, 2, 11, $year), $timezone) === DateTime::SUNDAY) {
+                $res[12] = DateTime::COMPENSATING_HOLIDAY;
+            }
         }
         if ($year === 1989) {
             $res[24] = DateTime::THE_SHOWA_EMPEROR_DIED;
@@ -353,7 +354,7 @@ class JapaneseDate
         $VernalEquinoxDay = $this->getVernalEquinoxDay($year);
         $res[$this->getDay($VernalEquinoxDay, $timezone)] = DateTime::VERNAL_EQUINOX_DAY;
         // 振替休日確認
-        if ($this->getWeekday($VernalEquinoxDay, $timezone) === DateTime::SUNDAY) {
+        if ($year >= 1974 && $this->getWeekday($VernalEquinoxDay, $timezone) === DateTime::SUNDAY) {
             $res[$this->getDay($VernalEquinoxDay, $timezone) + 1] = DateTime::COMPENSATING_HOLIDAY;
         }
 
@@ -433,7 +434,7 @@ class JapaneseDate
             $res[29] = DateTime::THE_EMPEROR_S_BIRTHDAY;
         }
         // 振替休日確認
-        if ($this->getWeekday(mktime(0, 0, 0, 4, 29, $year), $timezone) === DateTime::SUNDAY) {
+        if ($year >= 1973 && $this->getWeekday(mktime(0, 0, 0, 4, 29, $year), $timezone) === DateTime::SUNDAY) {
             $res[30] = DateTime::COMPENSATING_HOLIDAY;
         } elseif ($year === 2019) {
             // 2019年、特別な祝日
@@ -471,12 +472,12 @@ class JapaneseDate
                 $res[4] = DateTime::COMPENSATING_HOLIDAY;
             }
         } elseif ($year >= 1947) {
-            if ($this->getWeekday(mktime(0, 0, 0, 5, 3, $year), $timezone) === DateTime::SUNDAY) {
+            if ($year >= 1973 && $this->getWeekday(mktime(0, 0, 0, 5, 3, $year), $timezone) === DateTime::SUNDAY) {
                 $res[4] = DateTime::COMPENSATING_HOLIDAY;
             }
         }
         $res[5] = DateTime::CHILDREN_S_DAY;
-        if ($this->getWeekday(mktime(0, 0, 0, 5, 5, $year), $timezone) === DateTime::SUNDAY) {
+        if ($year >= 1973 && $this->getWeekday(mktime(0, 0, 0, 5, 5, $year), $timezone) === DateTime::SUNDAY) {
             $res[6] = DateTime::COMPENSATING_HOLIDAY;
         }
         if ($year >= 2007) {
@@ -611,7 +612,7 @@ class JapaneseDate
         $res[$this->getDay($autumnEquinoxDay, $timezone)] = DateTime::AUTUMNAL_EQUINOX_DAY;
 
         // 振替休日確認
-        if ($this->getWeekday($autumnEquinoxDay, $timezone) === DateTime::SUNDAY) {
+        if ($year >= 1973 && $this->getWeekday($autumnEquinoxDay, $timezone) === DateTime::SUNDAY) {
             $res[$this->getDay($autumnEquinoxDay, $timezone) + 1] = DateTime::COMPENSATING_HOLIDAY;
         }
 
@@ -626,7 +627,7 @@ class JapaneseDate
         } elseif ($year >= 1966) {
             $res[15] = DateTime::RESPECT_FOR_SENIOR_CITIZENS_DAY;
             // 振替休日確認
-            if ($this->getWeekday(mktime(0, 0, 0, 9, 15, $year), $timezone) === DateTime::SUNDAY) {
+            if ($year >= 1973 && $this->getWeekday(mktime(0, 0, 0, 9, 15, $year), $timezone) === DateTime::SUNDAY) {
                 $res[16] = DateTime::COMPENSATING_HOLIDAY;
             }
         }
@@ -710,7 +711,7 @@ class JapaneseDate
         } elseif ($year >= 1966) {
             $res[10] = DateTime::LEGACY_SPORTS_DAY;
             // 振替休日確認
-            if ($this->getWeekday(mktime(0, 0, 0, 10, 10, $year), $timezone) === DateTime::SUNDAY) {
+            if ($year >= 1973 && $this->getWeekday(mktime(0, 0, 0, 10, 10, $year), $timezone) === DateTime::SUNDAY) {
                 $res[11] = DateTime::COMPENSATING_HOLIDAY;
             }
         }
@@ -735,7 +736,7 @@ class JapaneseDate
         $res = [];
         $res[3] = DateTime::CULTURE_DAY;
         // 振替休日確認
-        if ($this->getWeekday(mktime(0, 0, 0, 11, 3, $year), $timezone) === DateTime::SUNDAY) {
+        if ($year >= 1973 && $this->getWeekday(mktime(0, 0, 0, 11, 3, $year), $timezone) === DateTime::SUNDAY) {
             $res[4] = DateTime::COMPENSATING_HOLIDAY;
         }
 
@@ -745,7 +746,7 @@ class JapaneseDate
 
         $res[23] = DateTime::LABOR_THANKSGIVING_DAY;
         // 振替休日確認
-        if ($this->getWeekday(mktime(0, 0, 0, 11, 23, $year), $timezone) === DateTime::SUNDAY) {
+        if ($year >= 1973 && $this->getWeekday(mktime(0, 0, 0, 11, 23, $year), $timezone) === DateTime::SUNDAY) {
             $res[24] = DateTime::COMPENSATING_HOLIDAY;
         }
 

--- a/src/Traits/CacheSetting.php
+++ b/src/Traits/CacheSetting.php
@@ -93,7 +93,8 @@ trait CacheSetting
     protected function innerDateTime(string $date_text)
     {
         static $cache;
+        $key = static::class . ':' . $this->getTimezone()->getName() . ':' . $date_text;
 
-        return $cache[$date_text] ?? ($cache[$date_text] = new static($date_text, $this->getTimezone()));
+        return $cache[$key] ?? ($cache[$key] = new static($date_text, $this->getTimezone()));
     }
 }

--- a/src/Traits/Factory.php
+++ b/src/Traits/Factory.php
@@ -46,7 +46,8 @@ trait Factory
     public static function factory($date_time = null, $time_zone = null): DateTimeInterface
     {
         if (is_int($date_time)) {
-            return new static(date('Y-m-d H:i:s', $date_time), $time_zone);
+            $obj = new static('@' . $date_time);
+            return $time_zone !== null ? $obj->setTimezone($time_zone) : $obj;
         }
         if (ctype_digit($date_time)) {
             $check_time = strtotime($date_time);


### PR DESCRIPTION
- composer.json: PHPUnit ^7.4.4 → ^9.0 へ更新（PHP 8.2+対応）
- Cache::forever(): MODE_NONE時もメモリキャッシュが返っていた問題を修正
- CacheSetting::innerDateTime(): クラス名とタイムゾーンを無視していたキャッシュキーを修正
- Factory::factory(): intタイムスタンプをローカルTZで壁時計時刻として解釈していた問題を修正（@prefix使用）
- JapaneseDate: 建国記念の日を1967年以降・振替休日を1973/1974年以降に制限