### PR TITLE
v7系: 月齢・旧暦・キャッシュロジックの不具合を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 日本の祝日、暦など日本での日付処理(Date processing including Japanese holiday processing)
 =========================================
-[![CircleCI](https://circleci.com/gh/suzunone/JapaneseDate.svg?style=svg)](https://circleci.com/gh/suzunone/JapaneseDate)
-
-
 Introduction
 -----------------------------------------
 

--- a/src/Components/Cache.php
+++ b/src/Components/Cache.php
@@ -69,6 +69,10 @@ class Cache extends CacheMode
      */
     public static function forever(string $cache_name, Closure $function): mixed
     {
+        if (static::$mode === static::MODE_NONE) {
+            return $function();
+        }
+
         $cache = &static::$cache;
 
         if (isset($cache[$cache_name])) {

--- a/src/Components/Config.php
+++ b/src/Components/Config.php
@@ -71,7 +71,7 @@ class Config
     public static function getLC(int $year): array
     {
         $config = self::getConfig($year);
-        if (!count($config) || isset($config[self::KEY_LUNAR_CALENDAR])) {
+        if (!count($config) || !isset($config[self::KEY_LUNAR_CALENDAR])) {
             return [];
         }
 
@@ -93,7 +93,7 @@ class Config
     public static function getST(int $year): array
     {
         $config = self::getConfig($year);
-        if (!count($config) || isset($config[self::KEY_SOLAR_TERM])) {
+        if (!count($config) || !isset($config[self::KEY_SOLAR_TERM])) {
             return [];
         }
 

--- a/src/Components/JapaneseDate.php
+++ b/src/Components/JapaneseDate.php
@@ -215,7 +215,7 @@ class JapaneseDate
         $res = [];
         $res[1] = DateTime::NEW_YEAR_S_DAY;
         // 振替休日確認
-        if ($this->getWeekday(mktime(0, 0, 0, 1, 1, $year), $timezone) === DateTime::SUNDAY) {
+        if ($year >= 1974 && $this->getWeekday(mktime(0, 0, 0, 1, 1, $year), $timezone) === DateTime::SUNDAY) {
             $res[2] = DateTime::COMPENSATING_HOLIDAY;
         }
         if ($year >= 2000) {
@@ -226,7 +226,7 @@ class JapaneseDate
         } else {
             $res[15] = DateTime::COMING_OF_AGE_DAY;
             // 振替休日確認
-            if ($this->getWeekday(mktime(0, 0, 0, 1, 15, $year), $timezone) === DateTime::SUNDAY) {
+            if ($year >= 1974 && $this->getWeekday(mktime(0, 0, 0, 1, 15, $year), $timezone) === DateTime::SUNDAY) {
                 $res[16] = DateTime::COMPENSATING_HOLIDAY;
             }
         }
@@ -294,11 +294,12 @@ class JapaneseDate
         }
 
         $res = [];
-        $res[11] = DateTime::NATIONAL_FOUNDATION_DAY;
-
-        // 振替休日確認
-        if ($this->getWeekday(mktime(0, 0, 0, 2, 11, $year), $timezone) === DateTime::SUNDAY) {
-            $res[12] = DateTime::COMPENSATING_HOLIDAY;
+        if ($year >= 1967) {
+            $res[11] = DateTime::NATIONAL_FOUNDATION_DAY;
+            // 振替休日確認
+            if ($year >= 1974 && $this->getWeekday(mktime(0, 0, 0, 2, 11, $year), $timezone) === DateTime::SUNDAY) {
+                $res[12] = DateTime::COMPENSATING_HOLIDAY;
+            }
         }
         if ($year === 1989) {
             $res[24] = DateTime::THE_SHOWA_EMPEROR_DIED;
@@ -340,7 +341,7 @@ class JapaneseDate
         $vernalEquinoxDay = $this->getVernalEquinoxDay($year);
         $res[$this->getDay($vernalEquinoxDay, $timezone)] = DateTime::VERNAL_EQUINOX_DAY;
         // 振替休日確認
-        if ($this->getWeekday($vernalEquinoxDay, $timezone) === DateTime::SUNDAY) {
+        if ($year >= 1974 && $this->getWeekday($vernalEquinoxDay, $timezone) === DateTime::SUNDAY) {
             $res[$this->getDay($vernalEquinoxDay, $timezone) + 1] = DateTime::COMPENSATING_HOLIDAY;
         }
 
@@ -429,7 +430,7 @@ class JapaneseDate
             $res[29] = DateTime::THE_EMPEROR_S_BIRTHDAY;
         }
         // 振替休日確認
-        if ($this->getWeekday(mktime(0, 0, 0, 4, 29, $year), $timezone) === DateTime::SUNDAY) {
+        if ($year >= 1973 && $this->getWeekday(mktime(0, 0, 0, 4, 29, $year), $timezone) === DateTime::SUNDAY) {
             $res[30] = DateTime::COMPENSATING_HOLIDAY;
         } elseif ($year === 2019) {
             // 2019年、特別な祝日
@@ -467,12 +468,12 @@ class JapaneseDate
                 $res[4] = DateTime::COMPENSATING_HOLIDAY;
             }
         } elseif ($year >= 1947) {
-            if ($this->getWeekday(mktime(0, 0, 0, 5, 3, $year), $timezone) === DateTime::SUNDAY) {
+            if ($year >= 1973 && $this->getWeekday(mktime(0, 0, 0, 5, 3, $year), $timezone) === DateTime::SUNDAY) {
                 $res[4] = DateTime::COMPENSATING_HOLIDAY;
             }
         }
         $res[5] = DateTime::CHILDREN_S_DAY;
-        if ($this->getWeekday(mktime(0, 0, 0, 5, 5, $year), $timezone) === DateTime::SUNDAY) {
+        if ($year >= 1973 && $this->getWeekday(mktime(0, 0, 0, 5, 5, $year), $timezone) === DateTime::SUNDAY) {
             $res[6] = DateTime::COMPENSATING_HOLIDAY;
         }
         if ($year >= 2007) {
@@ -608,7 +609,7 @@ class JapaneseDate
         $res[$this->getDay($autumnEquinoxDay, $timezone)] = DateTime::AUTUMNAL_EQUINOX_DAY;
 
         // 振替休日確認
-        if ($this->getWeekday($autumnEquinoxDay, $timezone) === DateTime::SUNDAY) {
+        if ($year >= 1973 && $this->getWeekday($autumnEquinoxDay, $timezone) === DateTime::SUNDAY) {
             $res[$this->getDay($autumnEquinoxDay, $timezone) + 1] = DateTime::COMPENSATING_HOLIDAY;
         }
 
@@ -623,7 +624,7 @@ class JapaneseDate
         } elseif ($year >= 1966) {
             $res[15] = DateTime::RESPECT_FOR_SENIOR_CITIZENS_DAY;
             // 振替休日確認
-            if ($this->getWeekday(mktime(0, 0, 0, 9, 15, $year), $timezone) === DateTime::SUNDAY) {
+            if ($year >= 1973 && $this->getWeekday(mktime(0, 0, 0, 9, 15, $year), $timezone) === DateTime::SUNDAY) {
                 $res[16] = DateTime::COMPENSATING_HOLIDAY;
             }
         }
@@ -718,7 +719,7 @@ class JapaneseDate
         } elseif ($year >= 1966) {
             $res[10] = DateTime::LEGACY_SPORTS_DAY;
             // 振替休日確認
-            if ($this->getWeekday(mktime(0, 0, 0, 10, 10, $year), $timezone) === DateTime::SUNDAY) {
+            if ($year >= 1973 && $this->getWeekday(mktime(0, 0, 0, 10, 10, $year), $timezone) === DateTime::SUNDAY) {
                 $res[11] = DateTime::COMPENSATING_HOLIDAY;
             }
         }
@@ -743,7 +744,7 @@ class JapaneseDate
         $res = [];
         $res[3] = DateTime::CULTURE_DAY;
         // 振替休日確認
-        if ($this->getWeekday(mktime(0, 0, 0, 11, 3, $year), $timezone) === DateTime::SUNDAY) {
+        if ($year >= 1973 && $this->getWeekday(mktime(0, 0, 0, 11, 3, $year), $timezone) === DateTime::SUNDAY) {
             $res[4] = DateTime::COMPENSATING_HOLIDAY;
         }
 
@@ -753,7 +754,7 @@ class JapaneseDate
 
         $res[23] = DateTime::LABOR_THANKSGIVING_DAY;
         // 振替休日確認
-        if ($this->getWeekday(mktime(0, 0, 0, 11, 23, $year), $timezone) === DateTime::SUNDAY) {
+        if ($year >= 1973 && $this->getWeekday(mktime(0, 0, 0, 11, 23, $year), $timezone) === DateTime::SUNDAY) {
             $res[24] = DateTime::COMPENSATING_HOLIDAY;
         }
 

--- a/src/Components/LunarCalendar.php
+++ b/src/Components/LunarCalendar.php
@@ -549,8 +549,7 @@ class LunarCalendar
 
         $diff_time = $timestamp - self::BASE_TIME;
 
-        // return ($diff_time + 32400.0) / 86400.25 / 365.25;
-        return ($diff_time + 32400.0) / 31557691.3125;
+        return ($diff_time + 32400.0) / 31557600.0;
     }
 
     /**
@@ -593,20 +592,7 @@ class LunarCalendar
      */
     protected function normalizeAngle(float $angle): float
     {
-        if ($angle < 0) {
-            // マイナスなら、逆から正規化
-            $angle1 = $angle * -1;
-            $angle1 -= 360 * floor($angle1 / 360);
-
-            return 360 - $angle1;
-        }
-        if ($angle <= 360) {
-            // 基準値以内なら何もしない
-            return $angle;
-        }
-
-        // 基準以上なら、正規化
-        return $angle - 360 * floor($angle / 360);
+        return $angle - 360.0 * floor($angle / 360.0);
     }
 
     /**
@@ -708,7 +694,9 @@ class LunarCalendar
         $rm_moon += 1.2740 * sin(deg2rad($this->normalizeAngle(100.738 + 4133.3536 * $julian_year)));
         $rm_moon += 6.2887 * sin(deg2rad($this->normalizeAngle(134.961 + 4771.9886 * $julian_year + $tmp)));
 
-        return $rm_moon + $this->normalizeAngle(218.3161 + 4812.67881 * $julian_year);
+        return $this->normalizeAngle(
+            $rm_moon + $this->normalizeAngle(218.3161 + 4812.67881 * $julian_year)
+        );
     }
 
     /**

--- a/src/DateTime.php
+++ b/src/DateTime.php
@@ -76,7 +76,7 @@ use JapaneseDate\Traits\DateTimeImport;
  * @property string $lunarMonthText
  * @property int $lunarMonth
  * @property int $lunarYear
- * @property int $lunarYay
+ * @property int $lunarDay
  * @property bool $isLeapMonth
  */
 class DateTime extends Carbon

--- a/src/DateTimeImmutable.php
+++ b/src/DateTimeImmutable.php
@@ -75,7 +75,7 @@ use JapaneseDate\Traits\DateTimeImport;
  * @property string $lunarMonthText
  * @property int $lunarMonth
  * @property int $lunarYear
- * @property int $lunarYay
+ * @property int $lunarDay
  * @property bool $isLeapMonth
  */
 class DateTimeImmutable extends CarbonImmutable

--- a/src/Elements/SolarTermDate.php
+++ b/src/Elements/SolarTermDate.php
@@ -61,9 +61,9 @@ class SolarTermDate
 
     /**
      * @param string $key
-     * @return string|\JapaneseDate\DateTime|null|int
+     * @return string|\JapaneseDate\DateTime|null|int|bool|float
      */
-    public function __get(string $key): null|string|DateTime|int
+    public function __get(string $key): null|string|DateTime|int|bool|float
     {
         return $this->attribute[$key] ?? match ($key) {
             'solarTermText' => JapaneseDate::SOLAR_TERM[$this->solar_term],

--- a/src/Traits/CacheSetting.php
+++ b/src/Traits/CacheSetting.php
@@ -94,7 +94,8 @@ trait CacheSetting
     protected function innerDateTime(string $date_text): static
     {
         static $cache;
+        $key = static::class . ':' . $this->getTimezone()->getName() . ':' . $date_text;
 
-        return $cache[$date_text] ?? ($cache[$date_text] = new static($date_text, $this->getTimezone()));
+        return $cache[$key] ?? ($cache[$key] = new static($date_text, $this->getTimezone()));
     }
 }

--- a/src/Traits/Factory.php
+++ b/src/Traits/Factory.php
@@ -49,7 +49,8 @@ trait Factory
     public static function factory(int|float|string|DateTimeInterface|null $date_time = null, DateTimeZone|null $time_zone = null): static
     {
         if (is_int($date_time) || is_float($date_time)) {
-            return new static(date('Y-m-d H:i:s', $date_time), $time_zone);
+            $obj = new static('@' . (int) $date_time);
+            return $time_zone !== null ? $obj->setTimezone($time_zone) : $obj;
         }
 
 

--- a/src/Traits/Lunar.php
+++ b/src/Traits/Lunar.php
@@ -47,7 +47,14 @@ trait Lunar
      */
     public function getMoonAge(): float
     {
-        return $this->getLunarCalendar()->day;
+        return $this->LunarCalendar->moonAge(
+            (int) $this->year,
+            (int) $this->month,
+            (int) $this->day,
+            (float) $this->hour,
+            (float) $this->minute,
+            (float) $this->second
+        );
     }
 
     /**

--- a/tests/Test/JapaneseDate/Components/ConfigTest.php
+++ b/tests/Test/JapaneseDate/Components/ConfigTest.php
@@ -1,0 +1,122 @@
+<?php
+
+/**
+ * ConfigTest.php
+ *
+ * @category    Tests
+ * @package     JapaneseDate
+ * @subpackage  Tests
+ * @author      Suzunone<suzunone.eleven@gmail.com>
+ * @copyright   JapaneseDate
+ * @license     BSD-2
+ * @link        https://github.com/suzunone/JapaneseDate
+ * @see         https://github.com/suzunone/JapaneseDate
+ */
+
+namespace Tests\JapaneseDate\Components;
+
+use JapaneseDate\Components\Config;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(\JapaneseDate\Components\Config::class)]
+class ConfigTest extends TestCase
+{
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/japanese_date_config_test_' . uniqid('', true);
+        mkdir($this->tmpDir, 0777, true);
+
+        file_put_contents($this->tmpDir . '/2026.php', <<<'PHP'
+<?php
+return [
+    'lunarCalendar' => [
+        [
+            'year'              => 2026,
+            'month'             => 1,
+            'day'               => 19,
+            'lunar_year'        => 2025,
+            'lunar_month'       => 12,
+            'lunar_month_leap'  => false,
+        ],
+    ],
+    'solarTerm' => [
+        ['month' => 1, 'day' => 5, 'solar_term' => 21],
+    ],
+];
+PHP
+        );
+
+        Config::setLCPath([$this->tmpDir]);
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->tmpDir . '/2026.php');
+        @rmdir($this->tmpDir);
+        Config::setLCPath([]);
+    }
+
+    #[RunInSeparateProcess] #[PreserveGlobalState(false)]
+    public function test_getLC_returns_lunarCalendar_data()
+    {
+        $result = Config::getLC(2026);
+
+        $this->assertNotEmpty($result, 'getLC(2026) は空配列ではなく lunarCalendar データを返すべき');
+        $this->assertCount(1, $result);
+
+        $entry = $result[0];
+        $this->assertEquals(2026, $entry['year']);
+        $this->assertEquals(1, $entry['month']);
+        $this->assertEquals(19, $entry['day']);
+        $this->assertEquals(2025, $entry['lunar_year']);
+        $this->assertEquals(12, $entry['lunar_month']);
+        $this->assertFalse($entry['lunar_month_leap']);
+
+        // jd (ユリウス通日) が補完されること
+        $this->assertArrayHasKey('jd', $entry, 'jd キーが補完されること');
+        $this->assertGreaterThan(0, $entry['jd']);
+    }
+
+    #[RunInSeparateProcess] #[PreserveGlobalState(false)]
+    public function test_getST_returns_solarTerm_data()
+    {
+        $result = Config::getST(2026);
+
+        $this->assertNotEmpty($result, 'getST(2026) は空配列ではなく solarTerm データを返すべき');
+        $this->assertCount(1, $result);
+
+        $entry = $result[0];
+        $this->assertEquals(1, $entry['month']);
+        $this->assertEquals(5, $entry['day']);
+        $this->assertEquals(21, $entry['solar_term']);
+    }
+
+    #[RunInSeparateProcess] #[PreserveGlobalState(false)]
+    public function test_getLC_returns_empty_for_missing_year()
+    {
+        $result = Config::getLC(1800);
+        $this->assertSame([], $result);
+    }
+
+    #[RunInSeparateProcess] #[PreserveGlobalState(false)]
+    public function test_getST_returns_empty_for_missing_year()
+    {
+        $result = Config::getST(1800);
+        $this->assertSame([], $result);
+    }
+
+    #[RunInSeparateProcess] #[PreserveGlobalState(false)]
+    public function test_addLCPath()
+    {
+        Config::setLCPath([]);
+        Config::addLCPath($this->tmpDir);
+
+        $result = Config::getLC(2026);
+        $this->assertNotEmpty($result);
+    }
+}

--- a/tests/Test/JapaneseDate/Components/LunarCalendarTest.php
+++ b/tests/Test/JapaneseDate/Components/LunarCalendarTest.php
@@ -18,7 +18,9 @@
 namespace Tests\JapaneseDate\Components;
 
 use Carbon\Carbon;
+use DateTimeZone;
 use JapaneseDate\Components\LunarCalendar;
+use JapaneseDate\DateTime;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
@@ -64,10 +66,22 @@ class LunarCalendarTest extends TestCase
     {
         $LunarCalendar = LunarCalendar::factory();
 
+        // JY=0 の基準点: 2000-01-02 03:00:00 UTC (= 2000-01-02 12:00:00 JST)
         $this->assertEquals(
             0.0,
-            $this->invokeExecuteMethod($LunarCalendar, 'gregorian2JY', [2000, 1, 2, 3, 0, 0, 0])
+            $this->invokeExecuteMethod($LunarCalendar, 'gregorian2JY', [2000, 1, 2, 3, 0, 0])
         );
+
+        // 1ユリウス年後 (= 365.25日 = 31557600秒)
+        $actual = $this->invokeExecuteMethod($LunarCalendar, 'gregorian2JY', [2001, 1, 1, 9, 0, 0]);
+        $this->assertEqualsWithDelta(1.0, $actual, 1e-10);
+
+        // 長期差分の検証: 2025-01-01 09:00:00 UTC
+        $base   = DateTime::factory('2000-01-02 12:00:00', new DateTimeZone('UTC'))->timestamp;
+        $target = DateTime::factory('2025-01-01 09:00:00', new DateTimeZone('UTC'))->timestamp;
+        $expected = (($target - $base) + 32400.0) / 31557600.0;
+        $actual25 = $this->invokeExecuteMethod($LunarCalendar, 'gregorian2JY', [2025, 1, 1, 9, 0, 0]);
+        $this->assertEqualsWithDelta($expected, $actual25, 1e-10);
     }
 
     /**
@@ -358,6 +372,8 @@ class LunarCalendarTest extends TestCase
             '2024/11/01' => ['2024/11/01', []],
             '2024/12/01' => ['2024/12/01', []],
             '2024/12/31' => ['2024/12/31', []],
+            // 月黄経負値バグ修正後: 2034-03-20 が朔日として認識されること
+            '2034/03/20' => ['2034/03/20', []],
         ];
     }
 
@@ -392,6 +408,12 @@ class LunarCalendarTest extends TestCase
             '2020朔_after'  => [2020, 12, 16, 1, 17, 0, 1],
             '2019朔_before' => [2019, 11, 26, 0, 0, 0, 29],
             '2019朔'        => [2019, 11, 27, 0, 6, 0, 0],
+            // 月黄経負値バグ修正後: 朔は0付近になること
+            '2026朔'        => [2026, 3, 19, 10, 23, 0, 0],
+            // 朔前(0:00 JST)は前周期の29.x のままであること
+            '2026朔_before' => [2026, 3, 19, 0, 0, 0, 29],
+            // 2034-03-20 19:15 JST が国立天文台の朔
+            '2034朔'        => [2034, 3, 20, 19, 15, 0, 0],
         ];
     }
 
@@ -405,5 +427,48 @@ class LunarCalendarTest extends TestCase
         $LunarCalendar = LunarCalendar::factory();
 
         $this->assertEquals($moon_age, round($LunarCalendar->moonAge($year, $month, $day, $hour, $minute, $second)));
+    }
+
+    #[RunInSeparateProcess] #[PreserveGlobalState(false)]
+    public function test_jY2LongitudeMoon_normalized()
+    {
+        $LunarCalendar = LunarCalendar::factory();
+
+        // 2024-05-05 12:00:00: 旧実装では -0.194579 を返していた → [0, 360) に正規化されること
+        $actual1 = $this->invokeExecuteMethod(
+            $LunarCalendar,
+            'longitudeMoon',
+            [2024, 5, 5, 12, 0, 0]
+        );
+        $this->assertGreaterThanOrEqual(0.0, $actual1, '月黄経は0以上でなければならない');
+        $this->assertLessThan(360.0, $actual1, '月黄経は360未満でなければならない');
+        // 月は0度付近にある (355°<θ<360° または 0°<θ<5°)
+        $near0_1 = $actual1 > 355.0 || $actual1 < 5.0;
+        $this->assertTrue($near0_1, "月黄経({$actual1})は0度付近 (355<θ<360 or 0<θ<5) でなければならない");
+
+        // 2026-03-19 16:56:18: 旧実装では -1.634862 を返していた → [0, 360) に正規化されること
+        $actual2 = $this->invokeExecuteMethod(
+            $LunarCalendar,
+            'longitudeMoon',
+            [2026, 3, 19, 16, 56, 18]
+        );
+        $this->assertGreaterThanOrEqual(0.0, $actual2, '月黄経は0以上でなければならない');
+        $this->assertLessThan(360.0, $actual2, '月黄経は360未満でなければならない');
+        // 月は0度付近にある
+        $near0_2 = $actual2 > 355.0 || $actual2 < 5.0;
+        $this->assertTrue($near0_2, "月黄経({$actual2})は0度付近 (355<θ<360 or 0<θ<5) でなければならない");
+    }
+
+    #[RunInSeparateProcess] #[PreserveGlobalState(false)]
+    public function test_lunarDate_2034()
+    {
+        // 2034-03-20 19:15 JST が朔 → 旧暦 2/1 であること
+        $DateTime = DateTime::factory('2034-03-20');
+        $this->assertEquals(2034, (int) $DateTime->lunar_year);
+        $this->assertEquals(2, (int) $DateTime->lunar_month);
+        $this->assertEquals(1, (int) $DateTime->lunar_day);
+
+        $DateTime2 = DateTime::factory('2034-03-21');
+        $this->assertEquals(2, (int) $DateTime2->lunar_day);
     }
 }

--- a/tests/Test/JapaneseDate/LunarTest.php
+++ b/tests/Test/JapaneseDate/LunarTest.php
@@ -44,9 +44,17 @@ class LunarTest extends TestCase
     #[Covers('getMoonAge')]
     public function test_getMoonAge()
     {
+        // 2020-03-01 20:00 JST: 旧暦2020/2月の朔は2020-02-24 00:32 JST なので月齢≒6.8
         $DateTime = DateTime::factory('2020-03-01 20:00:00');
-        $DateTime->getMoonAge();
-        $this->assertEquals(7, $DateTime->getMoonAge());
+        $this->assertEqualsWithDelta(6.8, $DateTime->getMoonAge(), 0.5);
+
+        // 朔 (新月) の直後 → 月齢 ≒ 0
+        $DateTime = DateTime::factory('2026-02-17 21:01:00');
+        $this->assertEqualsWithDelta(0.0, $DateTime->getMoonAge(), 0.5);
+
+        // 旧暦日(6)ではなく月齢(float)を返すことを確認
+        $DateTime = DateTime::factory('2026-05-22 00:00:00');
+        $this->assertEqualsWithDelta(4.775640, $DateTime->getMoonAge(), 0.5);
     }
 
     #[Covers('__get')]


### PR DESCRIPTION
【月齢計算・旧暦計算・外部データ読み込み修正】
- normalizeAngle(): floor式に統一し360°→0°、負値を正しく処理
- jY2LongitudeMoon(): 最終戻り値をnormalizeAngle()で包み月黄経の負値バグを解消
- gregorian2JY(): 除数を31557691.3125→31557600.0（86400.0×365.25）に修正
- getMoonAge(): 旧暦日(day)ではなく実際の月齢(float)を返すよう修正
- Config::getLC()/getST(): isset→!issetに修正し外部マッピングが読み込まれないバグを解消

【キャッシュ・ファクトリー・祝日ロジック修正】
- Cache::forever(): MODE_NONE時もメモリキャッシュが返っていた問題を修正
- SolarTermDate::__get(): bool/floatをintに潰していた戻り値型を修正
- CacheSetting::innerDateTime(): クラス名とタイムゾーンを無視していたキャッシュキーを修正
- Factory::factory(): int/floatタイムスタンプをローカルTZで壁時計時刻として解釈していた問題を修正（@prefix使用）
- JapaneseDate: 建国記念の日を1967年以降・振替休日を1973/1974年以降に制限

テスト追加: 月黄経正規化・2026/2034年の朔・gregorian2JY精度・Config読み込み